### PR TITLE
RFC api to generate precompile statements

### DIFF
--- a/src/PackageCompilerX.jl
+++ b/src/PackageCompilerX.jl
@@ -5,6 +5,7 @@ using Libdl: Libdl
 using Pkg: Pkg
 
 include("juliaconfig.jl")
+include("gen_precompile_statements.jl")
 
 const CC = (Sys.iswindows() ? `x86_64-w64-mingw32-gcc` : `gcc`)
 

--- a/src/gen_precompile_statements.jl
+++ b/src/gen_precompile_statements.jl
@@ -1,0 +1,85 @@
+using Pkg: Pkg
+abstract type PrecompileSource end
+
+struct RunTests <: PrecompileSource
+    pkg::Symbol
+end
+struct RunUsing <: PrecompileSource
+    pkg::Symbol
+end
+struct RunFile <: PrecompileSource
+    path::String
+end
+struct RunCode <: PrecompileSource
+    code::String
+end
+struct StatementFile <: PrecompileSource
+    path::String
+end
+
+struct PrecompileStatements
+    statements::Vector{String}
+end
+
+PrecompileStatements() = PrecompileStatements(String[])
+
+function Base.merge!(o1::PrecompileStatements, o2::PrecompileStatements)
+    Base.append!(o1.statements, o2.statements)
+    o1
+end
+
+
+function populate_precompile_statement_file(tracefile::AbstractString, o::RunTests)
+    Pkg.test(String[string(o.pkg)], julia_args=["--trace-compile=$tracefile"])
+    tracefile
+end
+
+function populate_precompile_statement_file(tracefile::AbstractString, o::RunCode)
+    cmd = `$(Base.julia_cmd()) --trace-compile=$tracefile -e "$(o.code)"`
+    run(cmd)
+    tracefile
+end
+
+function populate_precompile_statement_file(tracefile::AbstractString, o::RunUsing)
+    @assert o.pkg != nothing
+    cmd = `$(Base.julia_cmd()) --trace-compile=$tracefile -e "using $(o.pkg)"`
+    run(cmd)
+    tracefile
+end
+
+function populate_precompile_statement_file(tracefile::AbstractString, o::RunFile)
+    @assert o.pkg != nothing
+    cmd = `$(Base.julia_cmd()) --trace-compile=$tracefile $(o.path)`
+    run(cmd)
+    tracefile
+end
+
+function populate_precompile_statement_file(tracefile::AbstractString, o::StatementFile)
+    cp(o.path, tracefile)
+    tracefile
+end
+
+function generate_statements(o::PrecompileSource)
+    mktemp() do path, io
+        populate_precompile_statement_file(path, o)
+        return load_precomiple_statements(path)
+    end
+end
+
+function generate_statements(precompile_sources)
+    mapreduce(generate_statements, merge!, precompile_sources, init=PrecompileStatements())
+end
+
+load_precompile_statements(path::AbstractString) = open(load_precompile_statements, path)
+load_precompile_statements(io::IO) = PrecompileStatements(readlines(io))
+
+function save(io::IO, o::PrecompileStatements)
+    for s in o.statements
+        println(io, s)
+    end
+end
+function save(path::AbstractString, o::PrecompileStatements)
+    open(path, "w") do io
+        save(io, o)
+    end
+end


### PR DESCRIPTION
Compiling julia lives on precompile statements, so I think its worth having an API for generating them. Can be used like:
```julia
t = [RunTests(:OhMyREPL), RunUsing(:Example), RunCode(""" "a" * "b" """)]
generate_statements(t)
```
If the approach and intent of PR looks good I will add tests, fix bugs and actually use it in `create_sysimage` and `create_object_file`.