### PR TITLE
CompatHelper: only update root manifest

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -21,4 +21,4 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main( (; registries) -> CompatHelper._update_manifests(pwd(); registries = registries) )'


### PR DESCRIPTION
Fixes the problem described in this comment: https://github.com/KristofferC/PackageCompilerX.jl/pull/49#discussion_r356514438

See also: https://github.com/bcbi/CompatHelper.jl/blob/master/README.md#custom-pre-commit-hooks