### PR TITLE
Allow user to customize `cpu_target` in `create_app`

### DIFF
--- a/src/PackageCompilerX.jl
+++ b/src/PackageCompilerX.jl
@@ -266,6 +266,8 @@ by setting the envirnment variable `JULIA_CC` to a path to a compiler
 
 - `replace_default::Bool`: If `true`, replaces the default system image which is automatically
    used when Julia starts. To replace with the one Julia ships with, use [`restore_default_sysimage()`](@ref)
+
+- `cpu_target::AbstractString`: The value to use for `JULIA_CPU_TARGET` when building the system image.
 """
 function create_sysimage(packages::Union{Symbol, Vector{Symbol}};
                          sysimage_path::Union{String,Nothing}=nothing,
@@ -469,6 +471,8 @@ compiler.
    to `true`.
 
 - `force::Bool`: Remove the folder `compiled_app` if it exists before creating the app.
+
+- `cpu_target::AbstractString`: The value to use for `JULIA_CPU_TARGET` when building the system image.
 """
 function create_app(package_dir::String,
                     app_dir::String;

--- a/src/PackageCompilerX.jl
+++ b/src/PackageCompilerX.jl
@@ -477,7 +477,8 @@ function create_app(package_dir::String,
                     incremental=false,
                     filter_stdlibs=false,
                     audit=true,
-                    force=false)
+                    force=false,
+                    cpu_target::String=APP_CPU_TARGET)
     precompile_statements_file = abspath.(precompile_statements_file)
     package_dir = abspath(package_dir)
     ctx = create_pkg_context(package_dir)
@@ -516,13 +517,13 @@ function create_app(package_dir::String,
             tmp_base_sysimage = joinpath(tmp, "tmp_sys.so")
             create_sysimage(Symbol[]; sysimage_path=tmp_base_sysimage, project=package_dir,
                             incremental=false, filter_stdlibs=filter_stdlibs,
-                            cpu_target=APP_CPU_TARGET)
+                            cpu_target=cpu_target)
 
             create_sysimage(Symbol(app_name); sysimage_path=sysimg_file, project=package_dir,
                             incremental=true,
                             precompile_execution_file=precompile_execution_file,
                             precompile_statements_file=precompile_statements_file,
-                            cpu_target=APP_CPU_TARGET,
+                            cpu_target=cpu_target,
                             base_sysimage=tmp_base_sysimage,
                             isapp=true)
         else
@@ -530,7 +531,7 @@ function create_app(package_dir::String,
                                               incremental=incremental, filter_stdlibs=filter_stdlibs,
                                               precompile_execution_file=precompile_execution_file,
                                               precompile_statements_file=precompile_statements_file,
-                                              cpu_target=APP_CPU_TARGET,
+                                              cpu_target=cpu_target,
                                               isapp=true)
         end
         create_executable_from_sysimg(; sysimage_path=sysimg_file, executable_path=app_name)


### PR DESCRIPTION
This allows the user to customize the CPU target when creating an app.

The default (and strongly recommended) value is `APP_CPU_TARGET`, but the user can override it.

Basically, this finishes what was started in #43 and #52