### PR TITLE
set BINDIR in output process

### DIFF
--- a/src/PackageCompilerX.jl
+++ b/src/PackageCompilerX.jl
@@ -157,6 +157,7 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
     # include all packages into the sysimg
     julia_code = """
         Base.reinit_stdio()
+        @eval Sys BINDIR = ccall(:jl_get_julia_bindir, Any, ())::String
         Base.init_load_path()
         Base.init_depot_path()
         """


### PR DESCRIPTION
Otherwise this still point towards buildbot paths and when code loading looks for packages something like `isfile` can throw when looking at weird paths.